### PR TITLE
chore: update version manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undraw-js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Js library for Undraw illustration",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Update version manually to 1.0.6.
The previous version was not published correctly. The version number included
in the build was wrong. The publish workflow will be updated to fix that.